### PR TITLE
Refactor scripts to load configurable paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ pip install -r requirements.txt
 ## Dataset preparation
 1. Prepare the DOTA-style dataset in YOLO format with matching `images/` and `labels/` folders for each split you plan to use (e.g. `train`, `val`, `test`).
 2. Update the dataset YAML (for example, `dota.yaml`) so that it references the absolute paths for your machine.
-3. Ensure the working directories referenced by the scripts exist. By default they use Kaggle notebook paths under `/kaggle/input/` and `/kaggle/working/`. When running locally, edit the constants at the top of each script to point to your dataset root and desired output folders.
+3. Ensure the working directories referenced in your configuration files exist. Sample Kaggle and local YAML files live in `configs/` – copy the closest one and tweak the paths for your environment.
 4. Validate that ground-truth labels use YOLO normalised coordinates; the symbolic pipeline expects `.txt` predictions/labels in that format.
 
 ## Workflow at a glance
@@ -31,65 +31,62 @@ pip install -r requirements.txt
 - **Knowledge-graph stage**
   - Build weighted co-occurrence and spatial-relation graphs from predictions and emit Prolog facts/visualisations (`weighted_kg_sahi.py`).
 
-Outputs are written into the locations defined by each script (for example `/kaggle/working/yolo/viz_results`, `/kaggle/working/predictions_refined`, and `/kaggle/working/knowledge_graph`). Adjust these paths when running outside Kaggle.
+Outputs are written into the locations defined in the YAML configuration files (for example `/kaggle/working/yolo/viz_results`, `/kaggle/working/predictions_refined`, and `/kaggle/working/knowledge_graph`). Adjust these paths when running outside Kaggle.
 
 ## Entry points
 
 ### `training.py` — neural training & inference
-- Installs Ultralytics, trains a YOLOv11-OBB model using the dataset pointed to by `DATA_YAML`, and runs inference on `TEST_IMAGE_DIR`.
-- Produces visualisations (`VISUALIZATION_DIR`), a JSON export of detections, and a zipped artifact for convenient download.
-- **Customising paths**: edit `DATA_YAML`, `TEST_IMAGE_DIR`, `VISUALIZATION_DIR`, and `MODEL_WEIGHTS_DIR` at the top of the file to match your environment. All directories are created automatically if they are missing.
+- Trains a YOLOv11-OBB model and runs inference over a held-out image set, saving annotated renders plus a JSON dump of detections.
+- **Customising paths**: provide a YAML file (see `configs/training_*.yaml`) via `--config` or override specific values with CLI flags like `--data-yaml`, `--test-image-dir`, and `--zip-source-dir`.
 - **Running**:
   ```bash
-  python training.py
+  python training.py --config configs/training_kaggle.yaml
+  # or override one-off values
+  python training.py --config configs/training_local.yaml --epochs 100 --conf-threshold 0.2
   ```
-  In Kaggle notebooks, run the cell directly; locally ensure CUDA/cuDNN are installed if you expect GPU acceleration.
+  The script validates that input paths exist and creates missing output folders. GPU acceleration is used automatically when `torch.cuda.is_available()` returns `True`.
 
 ### `nsai_pipeline.py` (`nsai pipeline.py`) — symbolic reasoning workflow
-- Stage 1 performs class-wise NMS over YOLO prediction `.txt` files in `RAW_PREDICTIONS_DIR` and writes the cleaned outputs to `NMS_PREDICTIONS_DIR`.
-- Stage 2 loads Prolog rules (`RULES_FILE`), applies confidence adjustments, and emits an explainability report at `REPORT_FILE` plus refined predictions in `REFINED_PREDICTIONS_DIR`.
-- Stage 3 evaluates mAP for the raw, NMS-filtered, and refined detections using TorchMetrics.
-- **Customising paths**: adjust the constants for the input/output folders (`RAW_PREDICTIONS_DIR`, `RULES_FILE`, etc.) so they point to your filesystem. Each stage creates its output folder if required.
+- Stage 1 performs class-wise NMS over YOLO prediction `.txt` files, Stage 2 applies Prolog-defined confidence modifiers, and Stage 3 reports TorchMetrics mAP for each variant of the predictions.
+- **Customising paths**: point the script at a YAML file such as `configs/pipeline_kaggle.yaml`, or override flags like `--raw-predictions-dir` and `--rules-file`. Output directories are created automatically.
 - **Dependencies**: requires `swi-prolog` at runtime for `pyswip`. Install via apt on Linux or use the Kaggle image where it is available.
 - **Running**:
   ```bash
-  python "nsai pipeline.py"
+  python "nsai pipeline.py" --config configs/pipeline_local.yaml
   ```
   (On shells that dislike spaces in filenames, quote or escape the path.)
 
 ### `sahi_yolo_prediction.py` (`sahi yolo prediction.py`) — sliced inference helper
-- Loads a trained YOLO checkpoint with SAHI to generate dense predictions over large images located in `TEST_IMAGES_DIR`.
-- Saves YOLO-format `.txt` prediction files to `OUTPUT_PREDICTIONS_DIR`, suitable as input for the symbolic pipeline.
-- **Customising paths**: set `MODEL_PATH`, `TEST_IMAGES_DIR`, and `OUTPUT_PREDICTIONS_DIR` to match where your weights, images, and target output folder live.
+- Loads a trained YOLO checkpoint with SAHI to generate dense predictions over large images, emitting YOLO-format `.txt` files ready for the symbolic pipeline.
+- **Customising paths**: use a YAML config (see `configs/prediction_*.yaml`) or pass flags like `--model-path`, `--test-images-dir`, and `--output-predictions-dir`.
 - **Running**:
   ```bash
-  python "sahi yolo prediction.py"
+  python "sahi yolo prediction.py" --config configs/prediction_kaggle.yaml
   ```
   GPU usage is automatic when `torch.cuda.is_available()` reports a device.
 
 ### `weighted_kg_sahi.py` (`weighted kg +sahi.py`) — knowledge-graph construction
-- Runs SAHI inference over the dataset splits declared in `DATA_SPLITS`, extracts spatial relations, and aggregates them into a weighted directed graph.
+- Runs SAHI inference over configured dataset splits, extracts spatial relations, and aggregates them into a weighted directed graph.
 - Emits:
-  - Prolog facts at `knowledge_graph/facts.pl` (relative to `WORK_DIR`).
-  - Visualisations at `knowledge_graph/knowledge_graph_visuals.png`.
-- **Customising paths**: update `MODEL_PATH`, `WORK_DIR`, `DATA_ROOT`, and the `DATA_SPLITS` dictionary so they reflect your dataset layout. Add or adjust relation filters (`ALLOWED_*` sets) to control which relations are recorded.
+  - Prolog facts at the configured `facts_filename` within `knowledge_graph_dir`.
+  - Visualisations at the configured `graph_filename`.
+- **Customising paths**: select a config file like `configs/knowledge_graph_kaggle.yaml` or override the CLI flags (`--model-path`, `--knowledge-graph-dir`, `--data-split train=/path/to/images/train`, etc.). Relation filter sets (`ALLOWED_*`) remain editable in the script if you need domain-specific tweaks.
 - **Running**:
   ```bash
-  python "weighted kg +sahi.py"
+  python "weighted kg +sahi.py" --config configs/knowledge_graph_local.yaml
   ```
-  The script creates the `knowledge_graph/` folder if missing.
 
 ## Troubleshooting
-- **Missing folders (e.g. `/kaggle/working/...`)**: create the directories manually or update the corresponding constants in each script before running. Every entry point calls `os.makedirs(..., exist_ok=True)` for its outputs, but the parent path must still be valid for your platform.
-- **Kaggle-specific default paths**: when running locally, replace `/kaggle/input/...` and `/kaggle/working/...` references with your local dataset and scratch directories. The simplest approach is to edit the constants at the top of the script or set environment variables and read them via `os.getenv` if you prefer to avoid modifying code.
+- **Missing folders (e.g. `/kaggle/working/...`)**: create the directories manually or update the relevant configuration values before running. Every entry point creates its output folders, but parent directories must already exist.
+- **Kaggle-specific default paths**: when running locally, replace `/kaggle/input/...` and `/kaggle/working/...` references inside the config files with your local dataset and scratch directories.
 - **Prolog not found**: install SWI-Prolog (e.g. `sudo apt-get install swi-prolog`) before running `nsai_pipeline.py`.
 - **GPU not detected**: verify that NVIDIA drivers and CUDA runtime compatible with your PyTorch version are installed. The scripts fall back to CPU, but performance will degrade significantly.
 - **Package install failures**: upgrade `pip` and ensure build tools such as `build-essential`, `cmake`, and Python headers are present when compiling packages like `pyswip`.
 
 ## Outputs and artefact locations
 - YOLO training runs: `runs/obb/<experiment_name>/` inside the working directory used by Ultralytics.
-- Visualisations and JSON predictions: `VISUALIZATION_DIR` in `training.py`.
-- Symbolic reports: `REFINED_PREDICTIONS_DIR` and `explainability_report1.csv` in `nsai_pipeline.py`.
-- Knowledge graph artefacts: `knowledge_graph/` under `WORK_DIR`.
+- Visualisations and JSON predictions: `visualization_dir` defined in your training config.
+- Symbolic reports: `refined_predictions_dir` and the configured `report_file` in the pipeline config.
+- Knowledge graph artefacts: the configured `knowledge_graph_dir`.
 
 Adjust the directory constants if you wish to persist results outside the transient Kaggle filesystem.

--- a/config_utils.py
+++ b/config_utils.py
@@ -1,0 +1,88 @@
+"""Utility helpers for loading YAML configuration files and validating paths."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, Mapping, MutableMapping, Optional
+
+import yaml
+
+
+class ConfigError(Exception):
+    """Raised when configuration loading or validation fails."""
+
+
+@dataclass
+class PathRequirement:
+    path: Path
+    description: str
+    expect_directory: bool = True
+    create: bool = False
+
+
+def load_config_file(config_path: Path) -> Dict[str, Any]:
+    """Load a YAML configuration file and return its contents.
+
+    Parameters
+    ----------
+    config_path:
+        Path to the YAML configuration file.
+
+    Raises
+    ------
+    ConfigError
+        If the configuration file does not exist or cannot be parsed.
+    """
+
+    config_path = Path(config_path).expanduser()
+    if not config_path.is_file():
+        raise ConfigError(f"Configuration file '{config_path}' was not found.")
+
+    try:
+        with config_path.open("r", encoding="utf-8") as fh:
+            data = yaml.safe_load(fh) or {}
+    except yaml.YAMLError as exc:  # pragma: no cover - defensive programming
+        raise ConfigError(f"Could not parse configuration file '{config_path}': {exc}") from exc
+
+    if not isinstance(data, MutableMapping):
+        raise ConfigError(
+            f"Configuration file '{config_path}' must define a mapping at the top level."
+        )
+
+    return dict(data)
+
+
+def apply_overrides(config: MutableMapping[str, Any], overrides: Mapping[str, Any]) -> Dict[str, Any]:
+    """Apply non-``None`` overrides to the configuration mapping."""
+
+    for key, value in overrides.items():
+        if value is not None:
+            config[key] = value
+    return dict(config)
+
+
+def ensure_paths(requirements: Iterable[PathRequirement]) -> None:
+    """Validate that required paths exist, creating directories when requested."""
+
+    for requirement in requirements:
+        path = requirement.path.expanduser()
+        if requirement.expect_directory:
+            if path.is_dir():
+                continue
+            if requirement.create:
+                path.mkdir(parents=True, exist_ok=True)
+                continue
+            raise ConfigError(f"{requirement.description} directory not found: '{path}'.")
+        else:
+            if path.is_file():
+                continue
+            raise ConfigError(f"{requirement.description} file not found: '{path}'.")
+
+
+def expand_path(value: Optional[str | Path]) -> Optional[Path]:
+    """Convert a user-supplied path-like value into a :class:`Path`."""
+
+    if value is None:
+        return None
+    return Path(value).expanduser()

--- a/configs/knowledge_graph_kaggle.yaml
+++ b/configs/knowledge_graph_kaggle.yaml
@@ -1,0 +1,13 @@
+# Sample configuration for building the knowledge graph on Kaggle.
+model_path: /kaggle/working/runs/detect/dota_experiment_aabb11_1024/weights/best.pt
+knowledge_graph_dir: /kaggle/working/knowledge_graph
+data_splits:
+  train: /kaggle/working/yolo/images/train
+  val: /kaggle/working/yolo/images/val
+confidence_threshold: 0.3
+slice_height: 1024
+slice_width: 1024
+overlap_height: 0.2
+overlap_width: 0.2
+facts_filename: facts.pl
+graph_filename: knowledge_graph_visuals.png

--- a/configs/knowledge_graph_local.yaml
+++ b/configs/knowledge_graph_local.yaml
@@ -1,0 +1,13 @@
+# Sample configuration for building the knowledge graph locally.
+model_path: /path/to/project/artifacts/best.pt
+knowledge_graph_dir: /path/to/project/knowledge_graph
+data_splits:
+  train: /path/to/project/data/images/train
+  val: /path/to/project/data/images/val
+confidence_threshold: 0.25
+slice_height: 1024
+slice_width: 1024
+overlap_height: 0.25
+overlap_width: 0.25
+facts_filename: facts.pl
+graph_filename: knowledge_graph_visuals.png

--- a/configs/pipeline_kaggle.yaml
+++ b/configs/pipeline_kaggle.yaml
@@ -1,0 +1,8 @@
+# Sample configuration for executing the neurosymbolic pipeline on Kaggle.
+raw_predictions_dir: /kaggle/working/predictions1
+nms_predictions_dir: /kaggle/working/predictions_nms
+refined_predictions_dir: /kaggle/working/predictions_refined
+ground_truth_dir: /kaggle/working/yolo/labels/val
+rules_file: /kaggle/working/rules.pl
+report_file: /kaggle/working/explainability_report.csv
+nms_iou_threshold: 0.6

--- a/configs/pipeline_local.yaml
+++ b/configs/pipeline_local.yaml
@@ -1,0 +1,8 @@
+# Sample configuration for executing the neurosymbolic pipeline locally.
+raw_predictions_dir: /path/to/project/predictions/raw
+nms_predictions_dir: /path/to/project/predictions/nms
+refined_predictions_dir: /path/to/project/predictions/refined
+ground_truth_dir: /path/to/project/data/labels/val
+rules_file: /path/to/project/prolog/rules.pl
+report_file: /path/to/project/reports/explainability_report.csv
+nms_iou_threshold: 0.5

--- a/configs/prediction_kaggle.yaml
+++ b/configs/prediction_kaggle.yaml
@@ -1,0 +1,9 @@
+# Sample configuration for running SAHI predictions on Kaggle.
+model_path: /kaggle/working/runs/detect/dota_experiment_aabb11_1024/weights/best.pt
+test_images_dir: /kaggle/working/yolo/images/val
+output_predictions_dir: /kaggle/working/predictions
+confidence_threshold: 0.01
+slice_height: 1024
+slice_width: 1024
+overlap_height: 0.2
+overlap_width: 0.2

--- a/configs/prediction_local.yaml
+++ b/configs/prediction_local.yaml
@@ -1,0 +1,9 @@
+# Sample configuration for running SAHI predictions locally.
+model_path: /path/to/project/artifacts/best.pt
+test_images_dir: /path/to/project/data/images/val
+output_predictions_dir: /path/to/project/predictions
+confidence_threshold: 0.05
+slice_height: 1024
+slice_width: 1024
+overlap_height: 0.25
+overlap_width: 0.25

--- a/configs/training_kaggle.yaml
+++ b/configs/training_kaggle.yaml
@@ -1,0 +1,14 @@
+# Sample configuration for running training on Kaggle.
+data_yaml: /kaggle/input/dota15c/dota.yaml
+model_name: yolo11n-obb.pt
+trained_model_name: dota_experiment_v11_1024
+test_image_dir: /kaggle/working/yolo/images/test
+visualization_dir: /kaggle/working/yolo/viz_results
+model_weights_dir: /kaggle/working/runs/obb/dota_experiment_v11_1024/weights
+zip_source_dir: /kaggle/working/yolo
+zip_output_path: /kaggle/working/yolo/final_results.zip
+imgsz: 1024
+epochs: 50
+batch: 8
+workers: 0
+conf_threshold: 0.3

--- a/configs/training_local.yaml
+++ b/configs/training_local.yaml
@@ -1,0 +1,14 @@
+# Sample configuration for running training on a local workstation.
+data_yaml: /path/to/dataset/dota.yaml
+model_name: yolo11n-obb.pt
+trained_model_name: local_dota_experiment
+test_image_dir: /path/to/project/data/images/test
+visualization_dir: /path/to/project/artifacts/viz_results
+model_weights_dir: /path/to/project/artifacts/runs/obb/local_dota_experiment/weights
+zip_source_dir: /path/to/project/artifacts
+zip_output_path: /path/to/project/artifacts/final_results.zip
+imgsz: 1024
+epochs: 50
+batch: 8
+workers: 4
+conf_threshold: 0.25

--- a/nsai pipeline.py
+++ b/nsai pipeline.py
@@ -1,376 +1,474 @@
-# stage1_preprocess.py
+"""Complete neurosymbolic pipeline orchestrating NMS, symbolic reasoning, and evaluation."""
 
-import os
+from __future__ import annotations
+
+import argparse
+import csv
+import math
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, Tuple
+
 import torch
 import torchvision
-from collections import defaultdict
+from pyswip import Prolog
+from torchmetrics.detection.mean_ap import MeanAveragePrecision
+
+from config_utils import (
+    ConfigError,
+    PathRequirement,
+    apply_overrides,
+    ensure_paths,
+    expand_path,
+    load_config_file,
+)
+
+DEFAULT_CONFIG_PATH = Path("configs/pipeline_kaggle.yaml")
 
 
-RAW_PREDICTIONS_DIR = '/kaggle/working/predictions1'
-NMS_PREDICTIONS_DIR = '/kaggle/working/predictions_nms'
-NMS_IOU_THRESHOLD = 0.6 
+# ---------------------------------------------------------------------------
+# Configuration helpers
+# ---------------------------------------------------------------------------
 
-def parse_predictions_for_nms(predictions_dir):
-    predictions = defaultdict(list)
-    for pred_file in os.listdir(predictions_dir):
-        if not pred_file.endswith('.txt'): continue
-        image_name = pred_file.replace('.txt', '.png')
-        with open(os.path.join(predictions_dir, pred_file), 'r') as f:
-            for line in f:
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run the neurosymbolic pipeline stages.")
+    parser.add_argument("--config", type=Path, help="Path to a YAML configuration file.")
+    parser.add_argument("--raw-predictions-dir", dest="raw_predictions_dir", help="Directory of raw YOLO predictions.")
+    parser.add_argument("--nms-predictions-dir", dest="nms_predictions_dir", help="Directory for NMS-filtered predictions.")
+    parser.add_argument("--refined-predictions-dir", dest="refined_predictions_dir", help="Directory for refined predictions.")
+    parser.add_argument("--ground-truth-dir", dest="ground_truth_dir", help="Directory containing YOLO-format labels.")
+    parser.add_argument("--rules-file", dest="rules_file", help="Prolog rules file path.")
+    parser.add_argument("--report-file", dest="report_file", help="Explainability report output path.")
+    parser.add_argument("--nms-iou-threshold", dest="nms_iou_threshold", type=float, help="IOU threshold used for NMS stage.")
+    return parser.parse_args()
+
+
+def load_configuration(args: argparse.Namespace) -> Dict[str, Any]:
+    config: Dict[str, Any] = {
+        "nms_iou_threshold": 0.6,
+        "class_map": {
+            0: "plane",
+            1: "ship",
+            2: "storage_tank",
+            3: "baseball_diamond",
+            4: "tennis_court",
+            5: "basketball_court",
+            6: "Ground_Track_Field",
+            7: "harbor",
+            8: "Bridge",
+            9: "large_vehicle",
+            10: "small_vehicle",
+            11: "helicopter",
+            12: "roundabout",
+            13: "soccer_ball_field",
+            14: "swimming_pool",
+        },
+    }
+
+    config_path = args.config
+    if config_path is None and DEFAULT_CONFIG_PATH.is_file():
+        config_path = DEFAULT_CONFIG_PATH
+
+    if config_path is not None:
+        config.update(load_config_file(config_path))
+
+    overrides = {
+        "raw_predictions_dir": args.raw_predictions_dir,
+        "nms_predictions_dir": args.nms_predictions_dir,
+        "refined_predictions_dir": args.refined_predictions_dir,
+        "ground_truth_dir": args.ground_truth_dir,
+        "rules_file": args.rules_file,
+        "report_file": args.report_file,
+        "nms_iou_threshold": args.nms_iou_threshold,
+    }
+    config = apply_overrides(config, overrides)
+
+    required_keys = [
+        "raw_predictions_dir",
+        "nms_predictions_dir",
+        "refined_predictions_dir",
+        "ground_truth_dir",
+        "rules_file",
+        "report_file",
+    ]
+    for key in required_keys:
+        if key not in config or config[key] is None:
+            raise ConfigError(f"Configuration value '{key}' is required. Provide it via the YAML file or CLI flag.")
+
+    config["raw_predictions_dir"] = expand_path(config["raw_predictions_dir"])
+    config["nms_predictions_dir"] = expand_path(config["nms_predictions_dir"])
+    config["refined_predictions_dir"] = expand_path(config["refined_predictions_dir"])
+    config["ground_truth_dir"] = expand_path(config["ground_truth_dir"])
+    config["rules_file"] = expand_path(config["rules_file"])
+    config["report_file"] = expand_path(config["report_file"])
+
+    ensure_paths(
+        [
+            PathRequirement(config["raw_predictions_dir"], "Raw predictions", expect_directory=True),
+            PathRequirement(config["nms_predictions_dir"], "NMS predictions", expect_directory=True, create=True),
+            PathRequirement(config["refined_predictions_dir"], "Refined predictions", expect_directory=True, create=True),
+            PathRequirement(config["ground_truth_dir"], "Ground truth", expect_directory=True),
+            PathRequirement(config["rules_file"], "Prolog rules", expect_directory=False),
+            PathRequirement(config["report_file"].parent, "Report parent", expect_directory=True, create=True),
+        ]
+    )
+
+    config["class_map"] = _normalise_class_map(config["class_map"])
+    return config
+
+
+def _normalise_class_map(class_map: Any) -> Dict[int, str]:
+    if isinstance(class_map, Mapping):
+        return {int(key): str(value) for key, value in class_map.items()}
+    if isinstance(class_map, Iterable):
+        return {idx: str(name) for idx, name in enumerate(class_map)}
+    raise ConfigError("'class_map' must be defined as a mapping or list in the configuration file.")
+
+
+# ---------------------------------------------------------------------------
+# Stage 1 – Pre-processing with NMS
+# ---------------------------------------------------------------------------
+
+def parse_predictions_for_nms(predictions_dir: Path) -> Dict[str, List[Dict[str, Any]]]:
+    predictions: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
+    for pred_file in predictions_dir.iterdir():
+        if pred_file.suffix.lower() != ".txt":
+            continue
+        image_name = pred_file.with_suffix(".png").name
+        with pred_file.open("r", encoding="utf-8") as fh:
+            for line in fh:
                 parts = line.strip().split()
-                if len(parts) != 6: continue
+                if len(parts) != 6:
+                    continue
                 category_id, cx, cy, w, h, conf = map(float, parts)
-                predictions[image_name].append({
-                    'category_id': int(category_id),
-                    'bbox_yolo': [cx, cy, w, h], 
-                    'bbox_voc': [cx - w / 2, cy - h / 2, cx + w / 2, cy + h / 2],
-                    'confidence': conf
-                })
+                predictions[image_name].append(
+                    {
+                        "category_id": int(category_id),
+                        "bbox_yolo": [cx, cy, w, h],
+                        "bbox_voc": [cx - w / 2, cy - h / 2, cx + w / 2, cy + h / 2],
+                        "confidence": conf,
+                    }
+                )
     return predictions
 
-def pre_filter_with_nms(objects_in_image, iou_threshold):
-    if not objects_in_image: return []
-    objects_by_class = defaultdict(list)
+
+def pre_filter_with_nms(objects_in_image: List[Dict[str, Any]], iou_threshold: float) -> List[Dict[str, Any]]:
+    if not objects_in_image:
+        return []
+
+    objects_by_class: Dict[int, List[Dict[str, Any]]] = defaultdict(list)
     for obj in objects_in_image:
-        objects_by_class[obj['category_id']].append(obj)
-    
-    filtered_objects = []
-    for cat_id, objects in objects_by_class.items():
+        objects_by_class[obj["category_id"]].append(obj)
+
+    filtered_objects: List[Dict[str, Any]] = []
+    for objects in objects_by_class.values():
         if len(objects) < 2:
             filtered_objects.extend(objects)
             continue
-        boxes = torch.tensor([obj['bbox_voc'] for obj in objects], dtype=torch.float32)
-        scores = torch.tensor([obj['confidence'] for obj in objects], dtype=torch.float32)
+        boxes = torch.tensor([obj["bbox_voc"] for obj in objects], dtype=torch.float32)
+        scores = torch.tensor([obj["confidence"] for obj in objects], dtype=torch.float32)
         keep_indices = torchvision.ops.nms(boxes, scores, iou_threshold)
-        for i in keep_indices:
-            filtered_objects.append(objects[i])
+        filtered_objects.extend(objects[idx] for idx in keep_indices)
     return filtered_objects
 
-def save_predictions_to_file(predictions_dict, output_dir):
-    os.makedirs(output_dir, exist_ok=True)
-    for image_name, objects in predictions_dict.items():
-        txt_file_name = image_name.replace('.png', '.txt')
-        with open(os.path.join(output_dir, txt_file_name), 'w') as f:
-            for obj in objects:
-                cat_id = obj['category_id']
-                conf = obj['confidence']
-                cx, cy, w, h = obj['bbox_yolo']
-                f.write(f"{cat_id} {cx} {cy} {w} {h} {conf}\n")
 
-# --- Main Execution Block ---
-if __name__ == '__main__':
+def save_predictions_to_file(predictions_dict: Mapping[str, List[Dict[str, Any]]], output_dir: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    for image_name, objects in predictions_dict.items():
+        txt_file = output_dir / (Path(image_name).stem + ".txt")
+        with txt_file.open("w", encoding="utf-8") as fh:
+            for obj in objects:
+                cat_id = obj["category_id"]
+                conf = obj["confidence"]
+                cx, cy, w, h = obj["bbox_yolo"]
+                fh.write(f"{cat_id} {cx} {cy} {w} {h} {conf}\n")
+
+
+def run_stage_one(config: Dict[str, Any]) -> None:
     print("--- Stage 1: Pre-processing with NMS ---")
-    
-    raw_predictions = parse_predictions_for_nms(RAW_PREDICTIONS_DIR)
+    raw_predictions = parse_predictions_for_nms(config["raw_predictions_dir"])
     print(f"Loaded {len(raw_predictions)} raw prediction files.")
 
-    nms_predictions = defaultdict(list)
-    total_before = 0
-    total_after = 0
+    nms_predictions: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
+    total_before, total_after = 0, 0
     for image_name, objects in raw_predictions.items():
         total_before += len(objects)
-        filtered = pre_filter_with_nms(objects, NMS_IOU_THRESHOLD)
+        filtered = pre_filter_with_nms(objects, float(config["nms_iou_threshold"]))
         total_after += len(filtered)
         if filtered:
             nms_predictions[image_name] = filtered
 
     print(f"NMS completed. Reduced detections from {total_before} to {total_after}.")
-
-    save_predictions_to_file(nms_predictions, NMS_PREDICTIONS_DIR)
-    print(f"Cleaned predictions saved to '{NMS_PREDICTIONS_DIR}'")
-
+    save_predictions_to_file(nms_predictions, config["nms_predictions_dir"])
+    print(f"Cleaned predictions saved to '{config['nms_predictions_dir']}'.")
 
 
-# Symbolic reasoning and explainability report
+# ---------------------------------------------------------------------------
+# Stage 2 – Symbolic reasoning and explainability
+# ---------------------------------------------------------------------------
 
-!sudo apt-get update && sudo apt-get install -y swi-prolog
-!pip install pyswip
-
-import os
-import csv
-import math
-from pyswip import Prolog
-from collections import defaultdict
-
-NMS_PREDICTIONS_DIR = '/kaggle/working/predictions_nms'
-REFINED_PREDICTIONS_DIR = '/kaggle/working/predictions_refined'
-RULES_FILE = '/kaggle/working/rules.pl' 
-REPORT_FILE = '/kaggle/working/explainability_report1.csv'
+def get_center(bbox: Iterable[float]) -> Tuple[float, float]:
+    x1, y1, x2, y2 = bbox
+    return (x1 + x2) / 2, (y1 + y2) / 2
 
 
-def get_center(bbox):
-    return ((bbox[0] + bbox[2]) / 2, (bbox[1] + bbox[3]) / 2)
-
-def get_distance(bbox_a, bbox_b):
+def get_distance(bbox_a: Iterable[float], bbox_b: Iterable[float]) -> float:
     center_a, center_b = get_center(bbox_a), get_center(bbox_b)
     return math.hypot(center_a[0] - center_b[0], center_a[1] - center_b[1])
 
-def get_bbox_area(bbox):
-    return max(0, bbox[2] - bbox[0]) * max(0, bbox[3] - bbox[1])
 
-def get_intersection_area(bbox_a, bbox_b):
-    ix1, iy1 = max(bbox_a[0], bbox_b[0]), max(bbox_a[1], bbox_b[1])
-    ix2, iy2 = min(bbox_a[2], bbox_b[2]), min(bbox_a[3], bbox_b[3])
-    return max(0, ix2 - ix1) * max(0, iy2 - iy1)
+def get_bbox_area(bbox: Iterable[float]) -> float:
+    x1, y1, x2, y2 = bbox
+    return max(0.0, x2 - x1) * max(0.0, y2 - y1)
 
-def get_bbox_diag(bbox):
-    return math.hypot(bbox[2] - bbox[0], bbox[3] - bbox[1])
 
-def parse_predictions(predictions_dir):
-    predictions = defaultdict(list)
-    if not os.path.isdir(predictions_dir): return predictions
-    for pred_file in os.listdir(predictions_dir):
-        if not pred_file.endswith('.txt'): continue
-        image_name = pred_file.replace('.txt', '.png')
-        with open(os.path.join(predictions_dir, pred_file), 'r') as f:
-            for i, line in enumerate(f):
+def get_intersection_area(bbox_a: Iterable[float], bbox_b: Iterable[float]) -> float:
+    x1a, y1a, x2a, y2a = bbox_a
+    x1b, y1b, x2b, y2b = bbox_b
+    ix1, iy1 = max(x1a, x1b), max(y1a, y1b)
+    ix2, iy2 = min(x2a, x2b), min(y2a, y2b)
+    return max(0.0, ix2 - ix1) * max(0.0, iy2 - iy1)
+
+
+def get_bbox_diag(bbox: Iterable[float]) -> float:
+    x1, y1, x2, y2 = bbox
+    return math.hypot(x2 - x1, y2 - y1)
+
+
+def parse_predictions(predictions_dir: Path) -> Dict[str, List[Dict[str, Any]]]:
+    predictions: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
+    if not predictions_dir.exists():
+        return predictions
+    for pred_file in predictions_dir.iterdir():
+        if pred_file.suffix.lower() != ".txt":
+            continue
+        image_name = pred_file.with_suffix(".png").name
+        with pred_file.open("r", encoding="utf-8") as fh:
+            for idx, line in enumerate(fh):
                 parts = line.strip().split()
-                if len(parts) != 6: continue
+                if len(parts) != 6:
+                    continue
                 category_id, center_x, center_y, width, height, confidence = map(float, parts)
                 x_min, y_min = center_x - width / 2, center_y - height / 2
                 x_max, y_max = center_x + width / 2, center_y + height / 2
-                predictions[image_name].append({
-                    'id': f'det_{i}', 'category_id': int(category_id),
-                    'bbox': [x_min, y_min, x_max, y_max],
-                    'bbox_yolo': [center_x, center_y, width, height],
-                    'confidence': confidence
-                })
+                predictions[image_name].append(
+                    {
+                        "id": f"det_{idx}",
+                        "category_id": int(category_id),
+                        "bbox": [x_min, y_min, x_max, y_max],
+                        "bbox_yolo": [center_x, center_y, width, height],
+                        "confidence": confidence,
+                    }
+                )
     return predictions
 
-def load_prolog_modifiers(prolog_engine):
-    modifier_map = {}
-    query = "confidence_modifier(A, B, Weight)"
-    for solution in prolog_engine.query(query):
-        key = (solution['A'], solution['B'])
-        modifier_map[key] = solution['Weight']
+
+def load_prolog_modifiers(prolog_engine: Prolog) -> Dict[Tuple[str, str], float]:
+    modifier_map: Dict[Tuple[str, str], float] = {}
+    for solution in prolog_engine.query("confidence_modifier(A, B, Weight)"):
+        key = (solution["A"], solution["B"])
+        modifier_map[key] = solution["Weight"]
     return modifier_map
 
-def apply_symbolic_modifiers(objects_in_image, modifier_map, class_map):
-    modified_objects = {obj['id']: obj.copy() for obj in objects_in_image}
-    change_log = [] 
+
+def apply_symbolic_modifiers(
+    objects_in_image: List[Dict[str, Any]], modifier_map: Mapping[Tuple[str, str], float], class_map: Mapping[int, str]
+) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    modified_objects = {obj["id"]: dict(obj) for obj in objects_in_image}
+    change_log: List[Dict[str, Any]] = []
 
     obj_ids = list(modified_objects.keys())
-
     for i in range(len(obj_ids)):
         for j in range(i + 1, len(obj_ids)):
             id_a, id_b = obj_ids[i], obj_ids[j]
-            if id_a not in modified_objects or id_b not in modified_objects: continue
-
+            if id_a not in modified_objects or id_b not in modified_objects:
+                continue
             obj_a, obj_b = modified_objects[id_a], modified_objects[id_b]
-            class_a, class_b = class_map[obj_a['category_id']], class_map[obj_b['category_id']]
+            class_a, class_b = class_map[obj_a["category_id"]], class_map[obj_b["category_id"]]
+            original_conf_a, original_conf_b = obj_a["confidence"], obj_b["confidence"]
             weight = modifier_map.get((class_a, class_b)) or modifier_map.get((class_b, class_a))
-
-            if weight is None: continue
+            if weight is None:
+                continue
 
             log_entry = None
-            if weight > 1.0: 
-                avg_diag = (get_bbox_diag(obj_a['bbox']) + get_bbox_diag(obj_b['bbox'])) / 2
-                if get_distance(obj_a['bbox'], obj_b['bbox']) < 2 * avg_diag:
-                    original_conf_a, original_conf_b = obj_a['confidence'], obj_b['confidence']
-                    obj_a['confidence'] = min(1.0, original_conf_a * weight)
-                    obj_b['confidence'] = min(1.0, original_conf_b * weight)
-                    log_entry = {'action': 'BOOST', 'rule_pair': f"{class_a}<->{class_b}", 'object_1': class_a, 'conf_1_before': f"{original_conf_a:.2f}", 'conf_1_after': f"{obj_a['confidence']:.2f}", 'object_2': class_b, 'conf_2_before': f"{original_conf_b:.2f}", 'conf_2_after': f"{obj_b['confidence']:.2f}"}
-
-            elif weight < 1.0: 
-                intersection = get_intersection_area(obj_a['bbox'], obj_b['bbox'])
-                min_area = min(get_bbox_area(obj_a['bbox']), get_bbox_area(obj_b['bbox']))
+            if weight > 1.0:
+                avg_diag = (get_bbox_diag(obj_a["bbox"]) + get_bbox_diag(obj_b["bbox"])) / 2
+                if get_distance(obj_a["bbox"], obj_b["bbox"]) < 2 * avg_diag:
+                    obj_a["confidence"] = min(1.0, original_conf_a * weight)
+                    obj_b["confidence"] = min(1.0, original_conf_b * weight)
+                    log_entry = {
+                        "action": "BOOST",
+                        "rule_pair": f"{class_a}<->{class_b}",
+                        "object_1": class_a,
+                        "conf_1_before": f"{original_conf_a:.2f}",
+                        "conf_1_after": f"{obj_a['confidence']:.2f}",
+                        "object_2": class_b,
+                        "conf_2_before": f"{original_conf_b:.2f}",
+                        "conf_2_after": f"{obj_b['confidence']:.2f}",
+                    }
+            elif weight < 1.0:
+                intersection = get_intersection_area(obj_a["bbox"], obj_b["bbox"])
+                min_area = min(get_bbox_area(obj_a["bbox"]), get_bbox_area(obj_b["bbox"]))
                 if min_area > 0 and intersection / min_area > 0.5:
-                    suppressed_obj, kept_obj = (obj_b, obj_a) if obj_a['confidence'] > obj_b['confidence'] else (obj_a, obj_b)
-                    original_conf = suppressed_obj['confidence']
-                    suppressed_obj['confidence'] *= weight
-                    log_entry = {'action': 'PENALTY', 'rule_pair': f"{class_a}<->{class_b}", 'suppressed_object': class_map[suppressed_obj['category_id']], 'conf_before': f"{original_conf:.2f}", 'conf_after': f"{suppressed_obj['confidence']:.2f}", 'kept_object': class_map[kept_obj['category_id']], 'kept_object_conf': f"{kept_obj['confidence']:.2f}"}
-
+                    suppressed_obj, kept_obj = (
+                        (obj_b, obj_a) if obj_a["confidence"] > obj_b["confidence"] else (obj_a, obj_b)
+                    )
+                    original_conf = suppressed_obj["confidence"]
+                    suppressed_obj["confidence"] *= weight
+                    log_entry = {
+                        "action": "PENALTY",
+                        "rule_pair": f"{class_a}<->{class_b}",
+                        "object_1": class_a,
+                        "object_2": class_b,
+                        "conf_1_before": f"{original_conf_a:.2f}",
+                        "conf_1_after": f"{obj_a['confidence']:.2f}",
+                        "conf_2_before": f"{original_conf_b:.2f}",
+                        "conf_2_after": f"{obj_b['confidence']:.2f}",
+                        "suppressed_object": class_map[suppressed_obj["category_id"]],
+                        "conf_before": f"{original_conf:.2f}",
+                        "conf_after": f"{suppressed_obj['confidence']:.2f}",
+                        "kept_object": class_map[kept_obj["category_id"]],
+                        "kept_object_conf": f"{kept_obj['confidence']:.2f}",
+                    }
             if log_entry:
                 change_log.append(log_entry)
 
     return list(modified_objects.values()), change_log
 
-def save_predictions_to_file(predictions_dict, output_dir):
-    os.makedirs(output_dir, exist_ok=True)
-    for image_name, objects in predictions_dict.items():
-        txt_file_name = image_name.replace('.png', '.txt')
-        with open(os.path.join(output_dir, txt_file_name), 'w') as f:
-            for obj in objects:
-                cat_id = obj['category_id']
-                conf = obj['confidence']
-                cx, cy, w, h = obj['bbox_yolo']
-                f.write(f"{cat_id} {cx} {cy} {w} {h} {conf}\n")
 
-if __name__ == '__main__':
+def run_stage_two(config: Dict[str, Any]) -> None:
     print("--- Stage 2: Symbolic Reasoning (CPU-only) ---")
-    CLASS_MAP = {
-        0: 'plane', 1: 'ship', 2: 'storage_tank', 3: 'baseball_diamond', 4: 'tennis_court',
-        5: 'basketball_court', 6: 'Ground_Track_Field', 7: 'harbor', 8: 'Bridge',
-        9: 'large_vehicle', 10: 'small_vehicle', 11: 'helicopter', 12: 'roundabout',
-        13: 'soccer_ball_field', 14: 'swimming_pool'
-    }
-
     prolog = Prolog()
-    prolog.consult(RULES_FILE)
+    prolog.consult(str(config["rules_file"]))
     modifier_map = load_prolog_modifiers(prolog)
     print(f"Loaded {len(modifier_map)} modifier rules.")
 
-    nms_predictions = parse_predictions(NMS_PREDICTIONS_DIR)
+    nms_predictions = parse_predictions(config["nms_predictions_dir"])
     print(f"Loaded {len(nms_predictions)} NMS-filtered prediction files.")
 
-    refined_predictions = defaultdict(list)
-    full_report = []
+    refined_predictions: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
+    full_report: List[Dict[str, Any]] = []
+
     for image_name, objects in nms_predictions.items():
-        if not objects: continue
-        refined_objs, report_entries = apply_symbolic_modifiers(objects, modifier_map, CLASS_MAP)
+        if not objects:
+            continue
+        refined_objs, report_entries = apply_symbolic_modifiers(objects, modifier_map, config["class_map"])
         if refined_objs:
             refined_predictions[image_name] = refined_objs
         for entry in report_entries:
-            entry['image_name'] = image_name 
+            entry["image_name"] = image_name
             full_report.append(entry)
 
-    save_predictions_to_file(refined_predictions, REFINED_PREDICTIONS_DIR)
-    print(f"Final refined predictions saved to '{REFINED_PREDICTIONS_DIR}'")
+    save_predictions_to_file(refined_predictions, config["refined_predictions_dir"])
+    print(f"Final refined predictions saved to '{config['refined_predictions_dir']}'.")
 
     if full_report:
-        fieldnames = ['image_name', 'action', 'rule_pair', 'object_1', 'conf_1_before', 'conf_1_after', 'object_2', 'conf_2_before', 'conf_2_after']
-        with open(REPORT_FILE, 'w', newline='') as f:
-            writer = csv.DictWriter(f, fieldnames=fieldnames)
+        fieldnames = [
+            "image_name",
+            "action",
+            "rule_pair",
+            "object_1",
+            "conf_1_before",
+            "conf_1_after",
+            "object_2",
+            "conf_2_before",
+            "conf_2_after",
+            "suppressed_object",
+            "kept_object",
+            "kept_object_conf",
+        ]
+        with config["report_file"].open("w", newline="", encoding="utf-8") as fh:
+            writer = csv.DictWriter(fh, fieldnames=fieldnames)
             writer.writeheader()
             writer.writerows(full_report)
-        print(f"Explainability report saved to '{REPORT_FILE}'")
+        print(f"Explainability report saved to '{config['report_file']}'.")
     else:
         print("No symbolic reasoning actions were logged; explainability report not generated.")
 
 
+# ---------------------------------------------------------------------------
+# Stage 3 – Evaluation
+# ---------------------------------------------------------------------------
 
-!pip install torchmetrics -q
-!pip install torchmetrics detection -q
-!pip install faster-coco-eval -q
-!pip install pycocotools -q
-import os
-import torch
-from torchmetrics.detection.mean_ap import MeanAveragePrecision
-from collections import defaultdict
-
-# --- Configuration ---
-RAW_PREDICTIONS_DIR = '/kaggle/working/predictions1'
-NMS_PREDICTIONS_DIR = '/kaggle/working/predictions_nms'
-REFINED_PREDICTIONS_DIR = '/kaggle/working/predictions_refined'
-GROUND_TRUTH_DIR = '/kaggle/working/yolo/labels/val' 
-
-
-def parse_predictions(predictions_dir):
-    """Parses a directory of YOLO-format prediction files."""
-    predictions = defaultdict(list)
-    if not os.path.isdir(predictions_dir):
-        print(f"Warning: Prediction directory not found at {predictions_dir}")
-        return predictions
-
-    for pred_file in os.listdir(predictions_dir):
-        if not pred_file.endswith('.txt'):
+def parse_ground_truths(label_dir: Path) -> Dict[str, List[Dict[str, Any]]]:
+    ground_truths: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
+    for label_file in label_dir.iterdir():
+        if label_file.suffix.lower() != ".txt":
             continue
-
-        image_name = pred_file.replace('.txt', '.png')
-
-        with open(os.path.join(predictions_dir, pred_file), 'r') as f:
-            for line in f:
+        image_name = label_file.with_suffix(".png").name
+        with label_file.open("r", encoding="utf-8") as fh:
+            for line in fh:
                 parts = line.strip().split()
-                if len(parts) < 6: continue 
-
-                category_id = int(parts[0])
-                center_x, center_y, width, height, confidence = map(float, parts[1:])
-
-              
-                x_min = center_x - width / 2
-                y_min = center_y - height / 2
-                x_max = center_x + width / 2
-                y_max = center_y + height / 2
-
-                predictions[image_name].append({
-                    'category_id': category_id,
-                    'bbox': [x_min, y_min, x_max, y_max],
-                    'confidence': confidence
-                })
-    return predictions
-
-def parse_ground_truths(label_dir):
-    """Parses a directory of YOLO-format ground truth label files."""
-    ground_truths = defaultdict(list)
-    if not os.path.isdir(label_dir):
-        print(f"Warning: Ground truth directory not found at {label_dir}")
-        return ground_truths
-
-    for label_file in os.listdir(label_dir):
-        if not label_file.endswith('.txt'):
-            continue
-
-        image_name = label_file.replace('.txt', '.png') 
-        with open(os.path.join(label_dir, label_file), 'r') as f:
-            for line in f:
-                parts = line.strip().split()
-                if len(parts) < 5: continue
-
+                if len(parts) != 5:
+                    continue
                 category_id = int(parts[0])
                 center_x, center_y, width, height = map(float, parts[1:])
-
-                # Convert to VOC format
                 x_min = center_x - width / 2
                 y_min = center_y - height / 2
                 x_max = center_x + width / 2
                 y_max = center_y + height / 2
-
-                ground_truths[image_name].append({
-                    'category_id': category_id,
-                    'bbox': [x_min, y_min, x_max, y_max]
-                })
+                ground_truths[image_name].append(
+                    {
+                        "category_id": category_id,
+                        "bbox": [x_min, y_min, x_max, y_max],
+                    }
+                )
     return ground_truths
 
-def calculate_map(predictions, ground_truths):
-    """Calculates mAP using torchmetrics."""
-    metric = MeanAveragePrecision(box_format='xyxy')
 
-    preds_for_metric = []
-    targets_for_metric = []
+def calculate_map(predictions: Mapping[str, List[Dict[str, Any]]], ground_truths: Mapping[str, List[Dict[str, Any]]]) -> Dict[str, torch.Tensor]:
+    metric = MeanAveragePrecision(box_format="xyxy")
+    preds_for_metric, targets_for_metric = [], []
 
-    for image_name in ground_truths.keys():
-       
+    for image_name, gt_objects in ground_truths.items():
         if image_name in predictions:
-            preds_for_metric.append({
-                'boxes': torch.tensor([p['bbox'] for p in predictions[image_name]], dtype=torch.float32),
-                'scores': torch.tensor([p['confidence'] for p in predictions[image_name]], dtype=torch.float32),
-                'labels': torch.tensor([p['category_id'] for p in predictions[image_name]], dtype=torch.int32),
-            })
-        else: 
-             preds_for_metric.append({
-                'boxes': torch.empty(0, 4, dtype=torch.float32),
-                'scores': torch.empty(0, dtype=torch.float32),
-                'labels': torch.empty(0, dtype=torch.int32),
-            })
+            preds_for_metric.append(
+                {
+                    "boxes": torch.tensor([p["bbox"] for p in predictions[image_name]], dtype=torch.float32),
+                    "scores": torch.tensor([p["confidence"] for p in predictions[image_name]], dtype=torch.float32),
+                    "labels": torch.tensor([p["category_id"] for p in predictions[image_name]], dtype=torch.int64),
+                }
+            )
+        else:
+            preds_for_metric.append(
+                {
+                    "boxes": torch.empty((0, 4), dtype=torch.float32),
+                    "scores": torch.empty((0,), dtype=torch.float32),
+                    "labels": torch.empty((0,), dtype=torch.int64),
+                }
+            )
 
-        targets_for_metric.append({
-            'boxes': torch.tensor([gt['bbox'] for gt in ground_truths[image_name]], dtype=torch.float32),
-            'labels': torch.tensor([gt['category_id'] for gt in ground_truths[image_name]], dtype=torch.int32),
-        })
+        targets_for_metric.append(
+            {
+                "boxes": torch.tensor([gt["bbox"] for gt in gt_objects], dtype=torch.float32),
+                "labels": torch.tensor([gt["category_id"] for gt in gt_objects], dtype=torch.int64),
+            }
+        )
 
     metric.update(preds_for_metric, targets_for_metric)
     return metric.compute()
 
-if __name__ == '__main__':
+
+def run_stage_three(config: Dict[str, Any]) -> None:
     print("--- Stage 3: Final Evaluation ---")
 
     print("Loading ground truths")
-    ground_truths = parse_ground_truths(GROUND_TRUTH_DIR)
+    ground_truths = parse_ground_truths(config["ground_truth_dir"])
     print(f"Loaded {len(ground_truths)} ground truth files.")
 
     print("Loading raw YOLO predictions")
-    raw_preds = parse_predictions(RAW_PREDICTIONS_DIR)
+    raw_preds = parse_predictions(config["raw_predictions_dir"])
     print(f"Loaded {len(raw_preds)} raw prediction files.")
 
     print("Loading NMS-filtered predictions")
-    nms_preds = parse_predictions(NMS_PREDICTIONS_DIR)
+    nms_preds = parse_predictions(config["nms_predictions_dir"])
     print(f"Loaded {len(nms_preds)} NMS-filtered prediction files.")
 
     print("Loading final refined predictions")
-    refined_preds = parse_predictions(REFINED_PREDICTIONS_DIR)
+    refined_preds = parse_predictions(config["refined_predictions_dir"])
     print(f"Loaded {len(refined_preds)} refined prediction files.")
 
-    
     print("\n--- Calculating mAP for Raw YOLO Detections ---")
     map_raw = calculate_map(raw_preds, ground_truths)
 
@@ -384,13 +482,34 @@ if __name__ == '__main__':
     print("Metric          | Raw YOLO | NMS Only | Symbolic Refined")
     print("----------------|----------|----------|-----------------")
 
-    map50_raw = map_raw.get('map_50', torch.tensor(-1.0)).item()
-    map50_nms = map_nms.get('map_50', torch.tensor(-1.0)).item()
-    map50_refined = map_refined.get('map_50', torch.tensor(-1.0)).item()
+    map50_raw = map_raw.get("map_50", torch.tensor(-1.0)).item()
+    map50_nms = map_nms.get("map_50", torch.tensor(-1.0)).item()
+    map50_refined = map_refined.get("map_50", torch.tensor(-1.0)).item()
     print(f"mAP@.50         | {map50_raw:.4f}   | {map50_nms:.4f}   | {map50_refined:.4f}")
 
-    map_raw_val = map_raw.get('map', torch.tensor(-1.0)).item()
-    map_nms_val = map_nms.get('map', torch.tensor(-1.0)).item()
-    map_refined_val = map_refined.get('map', torch.tensor(-1.0)).item()
+    map_raw_val = map_raw.get("map", torch.tensor(-1.0)).item()
+    map_nms_val = map_nms.get("map", torch.tensor(-1.0)).item()
+    map_refined_val = map_refined.get("map", torch.tensor(-1.0)).item()
     print(f"mAP@.50:.95     | {map_raw_val:.4f}   | {map_nms_val:.4f}   | {map_refined_val:.4f}")
     print("==================================================")
+
+
+# ---------------------------------------------------------------------------
+# Entrypoint
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    args = parse_args()
+    try:
+        config = load_configuration(args)
+    except ConfigError as exc:
+        print(f"Configuration error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    run_stage_one(config)
+    run_stage_two(config)
+    run_stage_three(config)
+
+
+if __name__ == "__main__":
+    main()

--- a/sahi yolo prediction.py
+++ b/sahi yolo prediction.py
@@ -1,106 +1,167 @@
-!pip install ultralytics sahi
+"""Generate sliced SAHI predictions using a configurable YOLO model."""
 
-import os
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
 import torch
 from sahi import AutoDetectionModel
 from sahi.predict import get_sliced_prediction
 
+from config_utils import (
+    ConfigError,
+    PathRequirement,
+    apply_overrides,
+    ensure_paths,
+    expand_path,
+    load_config_file,
+)
 
-MODEL_PATH = '/kaggle/working/runs/detect/dota_experiment_aabb11_1024/weights/best.pt'
-TEST_IMAGES_DIR = '/kaggle/working/yolo/images/val'
+DEFAULT_CONFIG_PATH = Path("configs/prediction_kaggle.yaml")
 
-OUTPUT_PREDICTIONS_DIR = '/kaggle/working/predictions'
 
-MODEL_CONF_THRESH = 0.01
-SLICE_H, SLICE_W = 1024, 1024
-OVER_H, OVER_W = 0.2, 0.2
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run SAHI sliced predictions with YOLO.")
+    parser.add_argument("--config", type=Path, help="Path to a YAML configuration file.")
+    parser.add_argument("--model-path", dest="model_path", help="Path to the trained YOLO weights.")
+    parser.add_argument("--test-images-dir", dest="test_images_dir", help="Directory of images to predict on.")
+    parser.add_argument("--output-predictions-dir", dest="output_predictions_dir", help="Directory to write predictions.")
+    parser.add_argument("--confidence-threshold", dest="confidence_threshold", type=float, help="YOLO confidence threshold.")
+    parser.add_argument("--slice-height", dest="slice_height", type=int, help="Slice height for SAHI.")
+    parser.add_argument("--slice-width", dest="slice_width", type=int, help="Slice width for SAHI.")
+    parser.add_argument("--overlap-height", dest="overlap_height", type=float, help="Slice overlap height ratio.")
+    parser.add_argument("--overlap-width", dest="overlap_width", type=float, help="Slice overlap width ratio.")
+    return parser.parse_args()
 
-def main():
-    
-    device = 'cuda:0' if torch.cuda.is_available() else 'cpu'
+
+def load_configuration(args: argparse.Namespace) -> dict:
+    config = {
+        "confidence_threshold": 0.01,
+        "slice_height": 1024,
+        "slice_width": 1024,
+        "overlap_height": 0.2,
+        "overlap_width": 0.2,
+        "postprocess_type": "GREEDYNMM",
+        "postprocess_match_metric": "IOU",
+        "postprocess_match_threshold": 0.5,
+    }
+
+    config_path = args.config
+    if config_path is None and DEFAULT_CONFIG_PATH.is_file():
+        config_path = DEFAULT_CONFIG_PATH
+
+    if config_path is not None:
+        config.update(load_config_file(config_path))
+
+    overrides = {
+        "model_path": args.model_path,
+        "test_images_dir": args.test_images_dir,
+        "output_predictions_dir": args.output_predictions_dir,
+        "confidence_threshold": args.confidence_threshold,
+        "slice_height": args.slice_height,
+        "slice_width": args.slice_width,
+        "overlap_height": args.overlap_height,
+        "overlap_width": args.overlap_width,
+    }
+    config = apply_overrides(config, overrides)
+
+    for key in ("model_path", "test_images_dir", "output_predictions_dir"):
+        if key not in config or config[key] is None:
+            raise ConfigError(f"Configuration value '{key}' is required. Provide it via the YAML file or CLI flag.")
+
+    config["model_path"] = expand_path(config["model_path"])
+    config["test_images_dir"] = expand_path(config["test_images_dir"])
+    config["output_predictions_dir"] = expand_path(config["output_predictions_dir"])
+
+    ensure_paths(
+        [
+            PathRequirement(config["model_path"], "Model weights", expect_directory=False),
+            PathRequirement(config["test_images_dir"], "Test image", expect_directory=True),
+            PathRequirement(config["output_predictions_dir"], "Output predictions", expect_directory=True, create=True),
+        ]
+    )
+
+    return config
+
+
+def main() -> None:
+    args = parse_args()
+    try:
+        config = load_configuration(args)
+    except ConfigError as exc:
+        print(f"Configuration error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    device = "cuda:0" if torch.cuda.is_available() else "cpu"
     print(f"Using device: {device}")
 
     try:
         detection_model = AutoDetectionModel.from_pretrained(
-            model_type='yolov8',
-            model_path=MODEL_PATH,
-            confidence_threshold=MODEL_CONF_THRESH,
-            device=device
+            model_type="yolov8",
+            model_path=str(config["model_path"]),
+            confidence_threshold=float(config["confidence_threshold"]),
+            device=device,
         )
         print("YOLO model loaded successfully.")
-    except Exception as e:
-        print(f"ERROR loading model: {e}")
-        return
+    except Exception as exc:  # pragma: no cover - defensive programming
+        print(f"ERROR loading model: {exc}", file=sys.stderr)
+        sys.exit(1)
 
-    
-    if not os.path.isdir(TEST_IMAGES_DIR):
-        print(f"ERROR: Test image directory not found at '{TEST_IMAGES_DIR}'")
-        return
-        
-    image_files = [f for f in os.listdir(TEST_IMAGES_DIR) if f.lower().endswith(('.jpg', '.jpeg', '.png'))]
-    print(f"Found {len(image_files)} images to process.")
+    image_files = [p for p in sorted(config["test_images_dir"].iterdir()) if p.suffix.lower() in {".jpg", ".jpeg", ".png"}]
+    if not image_files:
+        print(
+            f"No images found in '{config['test_images_dir']}'. Ensure the directory contains .jpg/.jpeg/.png files.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
-    
-    os.makedirs(OUTPUT_PREDICTIONS_DIR, exist_ok=True)
-    print(f"🚀 Starting prediction generation...")
-    print(f"   All prediction files will be saved to: {OUTPUT_PREDICTIONS_DIR}")
+    print("🚀 Starting prediction generation...")
+    print(f"   All prediction files will be saved to: {config['output_predictions_dir']}")
 
-   
-    for i, img_name in enumerate(image_files):
-        img_path = os.path.join(TEST_IMAGES_DIR, img_name)
-        print(f"  Processing image {i+1}/{len(image_files)}: {img_name}", end='\r')
-
-        output_filename = os.path.splitext(img_name)[0] + ".txt"
-        output_filepath = os.path.join(OUTPUT_PREDICTIONS_DIR, output_filename)
+    for index, image_path in enumerate(image_files, start=1):
+        print(f"  Processing image {index}/{len(image_files)}: {image_path.name}", end="\r")
+        output_filepath = config["output_predictions_dir"] / (image_path.stem + ".txt")
 
         try:
             result = get_sliced_prediction(
-                img_path,
+                str(image_path),
                 detection_model,
-                slice_height=SLICE_H,
-                slice_width=SLICE_W,
-                overlap_height_ratio=OVER_H,
-                overlap_width_ratio=OVER_W,
-                postprocess_type="GREEDYNMM",
-                postprocess_match_metric="IOU",
-                postprocess_match_threshold=0.5,
-                verbose=0
+                slice_height=int(config["slice_height"]),
+                slice_width=int(config["slice_width"]),
+                overlap_height_ratio=float(config["overlap_height"]),
+                overlap_width_ratio=float(config["overlap_width"]),
+                postprocess_type=config.get("postprocess_type", "GREEDYNMM"),
+                postprocess_match_metric=config.get("postprocess_match_metric", "IOU"),
+                postprocess_match_threshold=float(config.get("postprocess_match_threshold", 0.5)),
+                verbose=0,
             )
+        except Exception as exc:  # pragma: no cover - defensive programming
+            print(f"\nError processing image {image_path.name}: {exc}", file=sys.stderr)
+            continue
 
-            img_h = result.image_height
-            img_w = result.image_width
+        img_h, img_w = result.image_height, result.image_width
+        with output_filepath.open("w", encoding="utf-8") as output_file:
+            for pred in result.object_prediction_list:
+                x1, y1, x2, y2 = pred.bbox.to_voc_bbox()
+                dw, dh = 1.0 / img_w, 1.0 / img_h
+                x_center = (x1 + x2) / 2.0
+                y_center = (y1 + y2) / 2.0
+                width = x2 - x1
+                height = y2 - y1
 
-            
-            with open(output_filepath, 'w') as output_f:
-                for pred in result.object_prediction_list:
-                    bbox = pred.bbox.to_voc_bbox()
-                    x1, y1, x2, y2 = bbox
-                    dw = 1. / img_w
-                    dh = 1. / img_h
-                    x_center = (x1 + x2) / 2.0
-                    y_center = (y1 + y2) / 2.0
-                    width = x2 - x1
-                    height = y2 - y1
+                x_center_norm = x_center * dw
+                y_center_norm = y_center * dh
+                width_norm = width * dw
+                height_norm = height * dh
 
-                    x_center_norm = x_center * dw
-                    y_center_norm = y_center * dh
-                    width_norm = width * dw
-                    height_norm = height * dh
+                output_file.write(
+                    f"{pred.category.id} {x_center_norm:.6f} {y_center_norm:.6f} {width_norm:.6f} {height_norm:.6f} {pred.score.value:.6f}\n"
+                )
 
-                    
-                    class_id = pred.category.id
-                    confidence = pred.score.value
-                    output_f.write(f"{class_id} {x_center_norm:.6f} {y_center_norm:.6f} {width_norm:.6f} {height_norm:.6f} {confidence:.6f}\n")
-
-        except Exception as e:
-            print(f"\nError processing image {img_name}: {e}")
-
-    print(f"\n Prediction generation complete. All files saved to the '{OUTPUT_PREDICTIONS_DIR}' directory.")
+    print("\nPrediction generation complete. All files saved to the output directory.")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()
-
-
-
-

--- a/training.py
+++ b/training.py
@@ -1,53 +1,142 @@
-!pip install ultralytics 
-import os
-import cv2
-import torch
-import numpy as np
-import subprocess
+"""Training and inference utilities for the YOLOv11 OBB model."""
+
+from __future__ import annotations
+
+import argparse
 import json
-from ultralytics import YOLO
-from PIL import Image
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict
+
+import cv2
 from tqdm import tqdm
-import matplotlib.pyplot as plt
+from ultralytics import YOLO
+
+from config_utils import (
+    ConfigError,
+    PathRequirement,
+    apply_overrides,
+    ensure_paths,
+    expand_path,
+    load_config_file,
+)
+
+DEFAULT_CONFIG_PATH = Path("configs/training_kaggle.yaml")
 
 
-DATA_YAML = '/kaggle/input/dota15c/dota.yaml'
-TRAINED_MODEL_NAME = 'dota_experiment_v11_1024'
-TEST_IMAGE_DIR = '/kaggle/working/yolo/images/test'
-VISUALIZATION_DIR = '/kaggle/working/yolo/viz_results'
-MODEL_WEIGHTS_DIR = '/kaggle/working/runs/obb/dota_experiment_v11_1024/weights'
-IMGSZ = 1024
-CONF_THRESH = 0.3
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Train YOLOv11-OBB and generate inference artefacts.")
+    parser.add_argument("--config", type=Path, help="Path to a YAML configuration file.")
+    parser.add_argument("--data-yaml", dest="data_yaml", help="Path to the dataset YAML description.")
+    parser.add_argument("--trained-model-name", dest="trained_model_name", help="Name of the Ultralytics run directory.")
+    parser.add_argument("--model-name", dest="model_name", help="Initial weights to use when constructing the YOLO model.")
+    parser.add_argument("--test-image-dir", dest="test_image_dir", help="Directory containing test images for inference.")
+    parser.add_argument("--visualization-dir", dest="visualization_dir", help="Directory in which to save annotated images.")
+    parser.add_argument("--model-weights-dir", dest="model_weights_dir", help="Directory containing trained model weights.")
+    parser.add_argument("--zip-output-path", dest="zip_output_path", help="Location for the zipped inference artefacts.")
+    parser.add_argument("--zip-source-dir", dest="zip_source_dir", help="Directory whose contents should be archived.")
+    parser.add_argument("--epochs", type=int, help="Number of training epochs.")
+    parser.add_argument("--imgsz", type=int, help="Inference and training image size.")
+    parser.add_argument("--batch", type=int, help="Training batch size.")
+    parser.add_argument("--workers", type=int, help="Number of dataloader workers.")
+    parser.add_argument(
+        "--conf-threshold", dest="conf_threshold", type=float, help="Confidence threshold used during inference.")
+    return parser.parse_args()
 
-os.makedirs(VISUALIZATION_DIR, exist_ok=True)
 
-def train_yolov11_obb():
-    model = YOLO("yolo11n-obb.pt") 
+def load_configuration(args: argparse.Namespace) -> Dict[str, Any]:
+    config: Dict[str, Any] = {
+        "model_name": "yolo11n-obb.pt",
+        "trained_model_name": "dota_experiment_v11_1024",
+        "imgsz": 1024,
+        "epochs": 50,
+        "batch": 8,
+        "workers": 0,
+        "conf_threshold": 0.3,
+    }
+
+    config_path = args.config
+    if config_path is None and DEFAULT_CONFIG_PATH.is_file():
+        config_path = DEFAULT_CONFIG_PATH
+
+    if config_path is not None:
+        config.update(load_config_file(config_path))
+
+    overrides = {
+        "data_yaml": args.data_yaml,
+        "model_name": args.model_name,
+        "trained_model_name": args.trained_model_name,
+        "test_image_dir": args.test_image_dir,
+        "visualization_dir": args.visualization_dir,
+        "model_weights_dir": args.model_weights_dir,
+        "zip_output_path": args.zip_output_path,
+        "zip_source_dir": args.zip_source_dir,
+        "epochs": args.epochs,
+        "imgsz": args.imgsz,
+        "batch": args.batch,
+        "workers": args.workers,
+        "conf_threshold": args.conf_threshold,
+    }
+    config = apply_overrides(config, overrides)
+
+    for key in ("data_yaml", "test_image_dir", "visualization_dir", "model_weights_dir", "zip_output_path"):
+        if key not in config or config[key] is None:
+            raise ConfigError(f"Configuration value '{key}' is required. Provide it via the YAML file or CLI flag.")
+
+    config["data_yaml"] = expand_path(config["data_yaml"])
+    config["test_image_dir"] = expand_path(config["test_image_dir"])
+    config["visualization_dir"] = expand_path(config["visualization_dir"])
+    config["model_weights_dir"] = expand_path(config["model_weights_dir"])
+    config["zip_output_path"] = expand_path(config["zip_output_path"])
+    if config.get("zip_source_dir") is None:
+        config["zip_source_dir"] = config["visualization_dir"]
+    config["zip_source_dir"] = expand_path(config["zip_source_dir"])
+
+    ensure_paths(
+        [
+            PathRequirement(config["data_yaml"], "Dataset YAML", expect_directory=False),
+            PathRequirement(config["test_image_dir"], "Test image", expect_directory=True),
+            PathRequirement(config["visualization_dir"], "Visualization", expect_directory=True, create=True),
+            PathRequirement(config["model_weights_dir"], "Model weights", expect_directory=True, create=True),
+            PathRequirement(config["zip_output_path"].parent, "Zip output parent", expect_directory=True, create=True),
+            PathRequirement(config["zip_source_dir"], "Zip source", expect_directory=True),
+        ]
+    )
+
+    return config
+
+
+def train_yolov11_obb(config: Dict[str, Any]) -> YOLO:
+    model = YOLO(config["model_name"])
     model.train(
-        data=DATA_YAML,
-        epochs=50,
-        imgsz=1024,
-        batch=8,
-        workers=0,
-        name=TRAINED_MODEL_NAME,
+        data=str(config["data_yaml"]),
+        epochs=int(config["epochs"]),
+        imgsz=int(config["imgsz"]),
+        batch=int(config["batch"]),
+        workers=int(config["workers"]),
+        name=str(config["trained_model_name"]),
         save=True,
-        save_txt=True
+        save_txt=True,
     )
     return model
 
-def run_inference(model_path, test_dir, output_dir, imgsz=1024, conf_thres=0.3):
-    model = YOLO(model_path)
+
+def run_inference(model_path: Path, config: Dict[str, Any]) -> Path:
+    model = YOLO(str(model_path))
+    output_dir = config["visualization_dir"]
+    output_dir.mkdir(parents=True, exist_ok=True)
     all_predictions = {}
 
-    for img_name in tqdm(os.listdir(test_dir)):
-        if not img_name.lower().endswith(('.png', '.jpg', '.jpeg')):
+    for img_name in tqdm(sorted(p.name for p in config["test_image_dir"].iterdir()), desc="Running inference"):
+        if not img_name.lower().endswith((".png", ".jpg", ".jpeg")):
             continue
 
-        img_path = os.path.join(test_dir, img_name)
-        results = model(img_path, imgsz=imgsz, conf=conf_thres)[0]
+        img_path = config["test_image_dir"] / img_name
+        results = model(str(img_path), imgsz=int(config["imgsz"]), conf=float(config["conf_threshold"]))[0]
 
         predictions = []
-        result_image = cv2.imread(img_path)
+        result_image = cv2.imread(str(img_path))
 
         if results and results.boxes:
             for box in results.boxes:
@@ -56,52 +145,80 @@ def run_inference(model_path, test_dir, output_dir, imgsz=1024, conf_thres=0.3):
                 cls_id = int(box.cls[0].item())
                 label = model.names[cls_id]
 
-                predictions.append({
-                    'class': label,
-                    'confidence': round(conf, 4),
-                    'bbox': [round(x, 2) for x in xyxy]
-                })
+                predictions.append(
+                    {
+                        "class": label,
+                        "confidence": round(conf, 4),
+                        "bbox": [round(x, 2) for x in xyxy],
+                    }
+                )
 
                 x1, y1, x2, y2 = map(int, xyxy)
                 cv2.rectangle(result_image, (x1, y1), (x2, y2), (0, 255, 0), 2)
-                cv2.putText(result_image, f"{label} {conf:.2f}", (x1, y1 - 10),
-                            cv2.FONT_HERSHEY_SIMPLEX, 0.6, (255, 255, 0), 2)
+                cv2.putText(
+                    result_image,
+                    f"{label} {conf:.2f}",
+                    (x1, y1 - 10),
+                    cv2.FONT_HERSHEY_SIMPLEX,
+                    0.6,
+                    (255, 255, 0),
+                    2,
+                )
 
-        out_path = os.path.join(output_dir, img_name)
-        cv2.imwrite(out_path, result_image)
+        out_path = output_dir / img_name
+        cv2.imwrite(str(out_path), result_image)
 
         all_predictions[img_name] = predictions
 
-    json_path = os.path.join(output_dir, "yolo_predictions.json")
-    with open(json_path, "w") as f:
-        json.dump(all_predictions, f, indent=2)
+    json_path = output_dir / "yolo_predictions.json"
+    with json_path.open("w", encoding="utf-8") as fh:
+        json.dump(all_predictions, fh, indent=2)
 
-    print(f"📄 JSON predictions saved to: {json_path}")
     return json_path
 
-def package_results():
-    zip_path = "/kaggle/working/yolo/final_results.zip"
-    subprocess.run(["zip", "-r", zip_path, "/kaggle/working/yolo"], check=False)
+
+def package_results(config: Dict[str, Any]) -> Path:
+    zip_path = config["zip_output_path"]
+    subprocess.run(["zip", "-r", str(zip_path), str(config["zip_source_dir"])], check=False)
     return zip_path
 
-if __name__ == "__main__":
-    print("Starting YOLOv11-OBB Training...")
-    trained_model = train_yolov11_obb()
 
-    best_model_path = trained_model.trainer.best if hasattr(trained_model.trainer, 'best') else os.path.join(MODEL_WEIGHTS_DIR, 'best.pt')
+def main() -> None:
+    args = parse_args()
+    try:
+        config = load_configuration(args)
+    except ConfigError as exc:
+        print(f"Configuration error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    print("Starting YOLOv11-OBB Training...")
+    trained_model = train_yolov11_obb(config)
+
+    best_model_path = None
+    if hasattr(trained_model, "trainer") and getattr(trained_model.trainer, "best", None):
+        best_model_path = Path(trained_model.trainer.best)
+    else:
+        candidate = config["model_weights_dir"] / "best.pt"
+        if candidate.is_file():
+            best_model_path = candidate
+
+    if best_model_path is None:
+        print(
+            "Unable to determine the best model weights automatically. Please check your training run.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
     print("Running Inference on Test Images...")
-    json_output = run_inference(
-        model_path=best_model_path,
-        test_dir=TEST_IMAGE_DIR,
-        output_dir=VISUALIZATION_DIR,
-        imgsz=IMGSZ,
-        conf_thres=CONF_THRESH
-    )
+    json_output = run_inference(best_model_path, config)
 
-    print(" Zipping Results for Download...")
-    zip_result_path = package_results()
+    print("Zipping Results for Download...")
+    zip_result_path = package_results(config)
 
-    print(f"Visual results saved to: {VISUALIZATION_DIR}")
+    print(f"Visual results saved to: {config['visualization_dir']}")
     print(f"JSON file saved to: {json_output}")
     print(f"Download zipped results from: {zip_result_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/weighted kg +sahi.py
+++ b/weighted kg +sahi.py
@@ -1,159 +1,353 @@
-!pip install ultralytics sahi networkx matplotlib
+"""Build a knowledge graph from SAHI predictions with configurable paths."""
 
-import os
+from __future__ import annotations
+
+import argparse
 import math
-import torch
-import networkx as nx
+import sys
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, Tuple
+
 import matplotlib.pyplot as plt
-from sahi.predict import get_sliced_prediction
+import networkx as nx
+import torch
 from sahi import AutoDetectionModel
+from sahi.predict import get_sliced_prediction
 
-MODEL_PATH = '/kaggle/working/runs/detect/dota_experiment_aabb11_1024/weights/best.pt'
-WORK_DIR = '/kaggle/working/'
-DATA_ROOT = '/kaggle/input/dota15c/dota.yaml' 
-DATA_SPLITS = {
-    'train': os.path.join(DATA_ROOT, '/kaggle/working/yolo/images/train') 
+from config_utils import (
+    ConfigError,
+    PathRequirement,
+    apply_overrides,
+    ensure_paths,
+    expand_path,
+    load_config_file,
+)
+
+DEFAULT_CONFIG_PATH = Path("configs/knowledge_graph_kaggle.yaml")
+
+ALLOWED_LOCATED_ON = {("large_vehicle", "Bridge")}
+ALLOWED_LOCATED_NEAR = {
+    ("ship", "harbor"),
+    ("small_vehicle", "small_vehicle"),
+    ("helicopter", "plane"),
+    ("small_vehicle", "roundabout"),
+    ("roundabout", "small_vehicle"),
+    ("storage_tank", "harbor"),
+    ("small_vehicle", "tennis_court"),
+    ("small_vehicle", "basketball_court"),
+    ("small_vehicle", "soccer_ball_field"),
+    ("small_vehicle", "Ground_Track_Field"),
+    ("small_vehicle", "baseball_diamond"),
 }
-CONF_THRESH = 0.3
-SLICE_H, SLICE_W = 1024, 1024
-OVER_H, OVER_W = 0.2, 0.2
+ALLOWED_ADJACENT_TO = {
+    ("tennis_court", "basketball_court"),
+    ("baseball_diamond", "soccer_ball_field"),
+    ("swimming_pool", "Ground_Track_Field"),
+    ("large_vehicle", "small_vehicle"),
+    ("plane", "plane"),
+}
 
-ALLOWED_LOCATED_ON = {('large_vehicle', 'Bridge')}
-ALLOWED_LOCATED_NEAR = { ('ship', 'harbor'), ('small_vehicle', 'small_vehicle'), ('helicopter', 'plane'), ('small_vehicle', 'roundabout'), ('roundabout', 'small_vehicle'), ('storage_tank', 'harbor'), ('small_vehicle', 'tennis_court'), ('small_vehicle', 'basketball_court'), ('small_vehicle', 'soccer_ball_field'), ('small_vehicle', 'Ground_Track_Field'), ('small_vehicle', 'baseball_diamond'), }
-ALLOWED_ADJACENT_TO = { ('tennis_court', 'basketball_court'), ('baseball_diamond', 'soccer_ball_field'), ('swimming_pool', 'Ground_Track_Field'), ('large_vehicle', 'small_vehicle'), ('plane', 'plane'), }
 
-KG_DIR = os.path.join(WORK_DIR, 'knowledge_graph')
-FACTS_PATH = os.path.join(KG_DIR, 'facts.pl')
-GRAPH_IMG_PATH = os.path.join(KG_DIR, 'knowledge_graph_visuals.png')
-os.makedirs(KG_DIR, exist_ok=True)
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate a weighted knowledge graph from SAHI predictions.")
+    parser.add_argument("--config", type=Path, help="Path to a YAML configuration file.")
+    parser.add_argument("--model-path", dest="model_path", help="Path to trained YOLO weights.")
+    parser.add_argument("--knowledge-graph-dir", dest="knowledge_graph_dir", help="Directory for KG artefacts.")
+    parser.add_argument("--data-split", dest="data_splits", action="append", help="Mapping of split=name:path entries.")
+    parser.add_argument("--confidence-threshold", dest="confidence_threshold", type=float, help="Model confidence threshold.")
+    parser.add_argument("--slice-height", dest="slice_height", type=int, help="Slice height for SAHI.")
+    parser.add_argument("--slice-width", dest="slice_width", type=int, help="Slice width for SAHI.")
+    parser.add_argument("--overlap-height", dest="overlap_height", type=float, help="Slice overlap height ratio.")
+    parser.add_argument("--overlap-width", dest="overlap_width", type=float, help="Slice overlap width ratio.")
+    return parser.parse_args()
 
-def get_center(bbox):
+
+def load_configuration(args: argparse.Namespace) -> Dict[str, Any]:
+    config: Dict[str, Any] = {
+        "confidence_threshold": 0.3,
+        "slice_height": 1024,
+        "slice_width": 1024,
+        "overlap_height": 0.2,
+        "overlap_width": 0.2,
+        "knowledge_graph_dir": Path("knowledge_graph"),
+        "facts_filename": "facts.pl",
+        "graph_filename": "knowledge_graph_visuals.png",
+    }
+
+    config_path = args.config
+    if config_path is None and DEFAULT_CONFIG_PATH.is_file():
+        config_path = DEFAULT_CONFIG_PATH
+
+    if config_path is not None:
+        config.update(load_config_file(config_path))
+
+    overrides = {
+        "model_path": args.model_path,
+        "knowledge_graph_dir": args.knowledge_graph_dir,
+        "confidence_threshold": args.confidence_threshold,
+        "slice_height": args.slice_height,
+        "slice_width": args.slice_width,
+        "overlap_height": args.overlap_height,
+        "overlap_width": args.overlap_width,
+    }
+    config = apply_overrides(config, overrides)
+
+    if args.data_splits:
+        split_mapping = {}
+        for item in args.data_splits:
+            if "=" not in item:
+                raise ConfigError("Data split overrides must be in 'name=path' format.")
+            name, value = item.split("=", 1)
+            split_mapping[name.strip()] = value.strip()
+        config["data_splits"] = split_mapping
+
+    for key in ("model_path", "knowledge_graph_dir"):
+        if key not in config or config[key] is None:
+            raise ConfigError(f"Configuration value '{key}' is required. Provide it via the YAML file or CLI flag.")
+
+    if "data_splits" not in config or not config["data_splits"]:
+        raise ConfigError("At least one data split must be defined in the configuration.")
+
+    config["model_path"] = expand_path(config["model_path"])
+    config["knowledge_graph_dir"] = expand_path(config["knowledge_graph_dir"])
+    config["data_splits"] = {name: expand_path(path) for name, path in config["data_splits"].items()}
+
+    ensure_paths(
+        [
+            PathRequirement(config["model_path"], "Model weights", expect_directory=False),
+            PathRequirement(config["knowledge_graph_dir"], "Knowledge graph", expect_directory=True, create=True),
+        ]
+    )
+
+    ensure_paths(
+        [
+            PathRequirement(path, f"Dataset split '{name}'", expect_directory=True)
+            for name, path in config["data_splits"].items()
+        ]
+    )
+
+    facts_filename = config.get("facts_filename", "facts.pl")
+    graph_filename = config.get("graph_filename", "knowledge_graph_visuals.png")
+    config["facts_path"] = config["knowledge_graph_dir"] / facts_filename
+    config["graph_image_path"] = config["knowledge_graph_dir"] / graph_filename
+
+    return config
+
+
+def get_center(bbox: Iterable[float]) -> Tuple[float, float]:
     x1, y1, x2, y2 = bbox
-    return ((x1 + x2) / 2, (y1 + y2) / 2)
+    return (x1 + x2) / 2, (y1 + y2) / 2
 
-def get_distance(bbox_a, bbox_b):
+
+def get_distance(bbox_a: Iterable[float], bbox_b: Iterable[float]) -> float:
     center_a, center_b = get_center(bbox_a), get_center(bbox_b)
     return math.hypot(center_a[0] - center_b[0], center_a[1] - center_b[1])
 
-def get_bbox_area(bbox):
-    x1, y1, x2, y2 = bbox
-    return max(0, x2 - x1) * max(0, y2 - y1)
 
-def get_intersection_area(bbox_a, bbox_b):
+def get_bbox_area(bbox: Iterable[float]) -> float:
+    x1, y1, x2, y2 = bbox
+    return max(0.0, x2 - x1) * max(0.0, y2 - y1)
+
+
+def get_intersection_area(bbox_a: Iterable[float], bbox_b: Iterable[float]) -> float:
     x1a, y1a, x2a, y2a = bbox_a
     x1b, y1b, x2b, y2b = bbox_b
     ix1, iy1 = max(x1a, x1b), max(y1a, y1b)
     ix2, iy2 = min(x2a, x2b), min(y2a, y2b)
-    return max(0, ix2 - ix1) * max(0, iy2 - iy1)
+    return max(0.0, ix2 - ix1) * max(0.0, iy2 - iy1)
 
-def get_bbox_diag(bbox):
+
+def get_bbox_diag(bbox: Iterable[float]) -> float:
     x1, y1, x2, y2 = bbox
     return math.hypot(x2 - x1, y2 - y1)
 
-# --- MODEL LOADING ---
-device = 'cuda:0' if torch.cuda.is_available() else 'cpu'
-print(f"Using device: {device}")
-try:
-    detection_model = AutoDetectionModel.from_pretrained(model_type='yolov8', model_path=MODEL_PATH, confidence_threshold=CONF_THRESH, device=device)
-except Exception as e:
-    print(f"Error loading model: {e}")
-    exit()
 
-# --- KG BUILDING ---
-G = nx.DiGraph()
-relation_counts = {}
-def add_relation(rel, obj_a_class, obj_b_class):
+def load_detection_model(config: Mapping[str, Any]) -> AutoDetectionModel:
+    device = "cuda:0" if torch.cuda.is_available() else "cpu"
+    print(f"Using device: {device}")
+    try:
+        detection_model = AutoDetectionModel.from_pretrained(
+            model_type="yolov8",
+            model_path=str(config["model_path"]),
+            confidence_threshold=float(config["confidence_threshold"]),
+            device=device,
+        )
+    except Exception as exc:  # pragma: no cover - defensive programming
+        raise ConfigError(f"Error loading model: {exc}") from exc
+    return detection_model
+
+
+def add_relation(relation_counts: Dict[Tuple[str, str, str], int], rel: str, obj_a_class: str, obj_b_class: str) -> None:
     key = (rel, obj_a_class, obj_b_class)
     relation_counts[key] = relation_counts.get(key, 0) + 1
 
-print("Starting fact extraction...")
-for split, img_dir in DATA_SPLITS.items():
-    if not os.path.isdir(img_dir):
-        print(f"Warning: Directory not found for split '{split}': {img_dir}")
-        continue
-    print(f"Processing split: {split}")
-    image_files = [f for f in os.listdir(img_dir) if f.lower().endswith(('.jpg', '.jpeg', '.png'))]
-    
-    for i, img_name in enumerate(image_files):
-        path = os.path.join(img_dir, img_name)
-        print(f"  Processing image {i+1}/{len(image_files)}: {img_name}", end='\r')
-        try:
-            result = get_sliced_prediction(path, detection_model, slice_height=SLICE_H, slice_width=SLICE_W, overlap_height_ratio=OVER_H, overlap_width_ratio=OVER_W, verbose=0)
+
+def process_dataset(
+    detection_model: AutoDetectionModel,
+    data_splits: Mapping[str, Path],
+    config: Mapping[str, Any],
+) -> Dict[Tuple[str, str, str], int]:
+    relation_counts: Dict[Tuple[str, str, str], int] = {}
+    for split, img_dir in data_splits.items():
+        image_files = [p for p in sorted(img_dir.iterdir()) if p.suffix.lower() in {".jpg", ".jpeg", ".png"}]
+        if not image_files:
+            print(f"Warning: Directory for split '{split}' does not contain any images: {img_dir}")
+            continue
+        print(f"Processing split: {split} ({len(image_files)} images)")
+        for index, image_path in enumerate(image_files, start=1):
+            print(f"  Processing image {index}/{len(image_files)}: {image_path.name}", end="\r")
+            try:
+                result = get_sliced_prediction(
+                    str(image_path),
+                    detection_model,
+                    slice_height=int(config["slice_height"]),
+                    slice_width=int(config["slice_width"]),
+                    overlap_height_ratio=float(config["overlap_height"]),
+                    overlap_width_ratio=float(config["overlap_width"]),
+                    verbose=0,
+                )
+            except Exception as exc:  # pragma: no cover - defensive programming
+                print(f"\nError processing image {image_path.name}: {exc}")
+                continue
+
             objects = [(o.category.name, o.score.value, o.bbox.to_voc_bbox()) for o in result.object_prediction_list]
-            
             for i in range(len(objects)):
                 c1, _, b1 = objects[i]
                 for j in range(i + 1, len(objects)):
                     c2, _, b2 = objects[j]
                     sorted_pair = tuple(sorted((c1, c2)))
-                    add_relation('cooccurs', sorted_pair[0], sorted_pair[1])
-                    
-                    for subject, object_, sub_bbox, obj_bbox in [(c1, c2, b1, b2), (c2, c1, b2, b1)]:
+                    add_relation(relation_counts, "cooccurs", sorted_pair[0], sorted_pair[1])
+
+                    for subject, object_, sub_bbox, obj_bbox in ((c1, c2, b1, b2), (c2, c1, b2, b1)):
                         pair = (subject, object_)
-                        
                         if pair in ALLOWED_LOCATED_ON and get_intersection_area(sub_bbox, obj_bbox) / get_bbox_area(sub_bbox) >= 0.5:
-                            add_relation('located_on', subject, object_)
-                        
-                        if pair in ALLOWED_LOCATED_NEAR and get_distance(sub_bbox, obj_bbox) < 2 * ((get_bbox_diag(sub_bbox) + get_bbox_diag(obj_bbox)) / 2):
-                            add_relation('located_near', subject, object_)
-                        
+                            add_relation(relation_counts, "located_on", subject, object_)
+                        if (
+                            pair in ALLOWED_LOCATED_NEAR
+                            and get_distance(sub_bbox, obj_bbox) < 2 * ((get_bbox_diag(sub_bbox) + get_bbox_diag(obj_bbox)) / 2)
+                        ):
+                            add_relation(relation_counts, "located_near", subject, object_)
                         if pair in ALLOWED_ADJACENT_TO:
                             eps = 0.1 * get_bbox_diag(sub_bbox)
                             x1a, y1a, x2a, y2a = sub_bbox
                             x1b, y1b, x2b, y2b = obj_bbox
-                            if (abs(x2a - x1b) <= eps or abs(x1a - x2b) <= eps or abs(y2a - y1b) <= eps or abs(y1a - y2b) <= eps):
-                                add_relation('adjacent_to', subject, object_)
+                            if (
+                                abs(x2a - x1b) <= eps
+                                or abs(x1a - x2b) <= eps
+                                or abs(y2a - y1b) <= eps
+                                or abs(y1a - y2b) <= eps
+                            ):
+                                add_relation(relation_counts, "adjacent_to", subject, object_)
+        print()
+    return relation_counts
 
-        except Exception as e:
-            print(f"\nError processing image {img_name}: {e}")
 
-print("\nFact extraction complete.")
-for (rel, A, B), count in relation_counts.items():
-    G.add_edge(A, B, relation=rel, weight=count)
+def write_prolog_facts(relation_counts: Mapping[Tuple[str, str, str], int], facts_path: Path) -> None:
+    with facts_path.open("w", encoding="utf-8") as fh:
+        fh.write("% fact(Relation, Subject, Object, Count).\n")
+        for (rel, subj, obj), count in sorted(relation_counts.items(), key=lambda item: item[0]):
+            fh.write(f"fact('{rel}', '{subj}', '{obj}', {count}).\n")
 
-with open(FACTS_PATH, 'w') as f:
-    f.write('% fact(Relation, Subject, Object, Count).\n')
-    for (rel, A, B), count in sorted(relation_counts.items(), key=lambda item: item[0]):
-        f.write(f"fact('{rel}', '{A}', '{B}', {count}).\n")
-print(f"Prolog facts written to: {FACTS_PATH}")
 
-relation_types = ['cooccurs', 'located_near', 'adjacent_to', 'located_on']
-relation_colors = {'cooccurs': '#d62728', 'located_near': '#2ca02c', 'adjacent_to': '#1f77b4', 'located_on': '#9467bd'}
+def visualise_graph(relation_counts: Mapping[Tuple[str, str, str], int], graph_path: Path) -> None:
+    relation_types = ["cooccurs", "located_near", "adjacent_to", "located_on"]
+    relation_colors = {
+        "cooccurs": "#d62728",
+        "located_near": "#2ca02c",
+        "adjacent_to": "#1f77b4",
+        "located_on": "#9467bd",
+    }
+    thresholds = {
+        "cooccurs": 12000,
+        "located_near": 20,
+        "adjacent_to": 75,
+        "located_on": 0,
+    }
 
-VISUALIZATION_THRESHOLDS = {
-    'cooccurs': 12000,
-    'located_near': 20,
-    'adjacent_to': 75,
-    'located_on': 0
-}
+    G = nx.DiGraph()
+    for (rel, subj, obj), count in relation_counts.items():
+        G.add_edge(subj, obj, relation=rel, weight=count)
 
-fig, axes = plt.subplots(len(relation_types), 1, figsize=(25, 20 * len(relation_types)))
-if len(relation_types) == 1: axes = [axes]
-print("Generating KG visualizations...")
+    if not relation_counts:
+        print("No relations were generated; skipping visualisation.")
+        return
 
-for ax, rel_type in zip(axes, relation_types):
-    min_weight = VISUALIZATION_THRESHOLDS.get(rel_type, 0)
-    subG = nx.DiGraph([(u, v, d) for u, v, d in G.edges(data=True) if d.get("relation") == rel_type and d.get("weight", 0) > min_weight])
-    
-    ax.set_title(f"Relation: {rel_type.replace('_', ' ').title()} (Count > {min_weight:,})", fontsize=24, fontweight='bold')
-    if not subG.nodes():
-        ax.text(0.5, 0.5, 'No relations found for this threshold', ha='center', va='center', fontsize=18)
+    fig, axes = plt.subplots(len(relation_types), 1, figsize=(25, 20 * len(relation_types)))
+    if len(relation_types) == 1:
+        axes = [axes]
+
+    for ax, rel_type in zip(axes, relation_types):
+        min_weight = thresholds.get(rel_type, 0)
+        subG = nx.DiGraph(
+            [(u, v, d) for u, v, d in G.edges(data=True) if d.get("relation") == rel_type and d.get("weight", 0) > min_weight]
+        )
+
+        ax.set_title(f"Relation: {rel_type.replace('_', ' ').title()} (Count > {min_weight:,})", fontsize=24, fontweight="bold")
+        if not subG.nodes:
+            ax.text(0.5, 0.5, "No relations found for this threshold", ha="center", va="center", fontsize=18)
+            ax.axis("off")
+            continue
+
+        pos = nx.spring_layout(subG, k=6.0 / math.sqrt(len(subG.nodes) + 0.01), seed=42, iterations=100)
+        node_sizes = [dict(subG.degree()).get(n, 1) * 1500 + 800 for n in subG.nodes]
+
+        edge_weights = [d["weight"] for _, _, d in subG.edges(data=True)]
+        max_weight = max(edge_weights) if edge_weights else 1
+        edge_widths = [((w / max_weight) * 8) + 1.5 for w in edge_weights]
+
+        nx.draw_networkx_nodes(subG, pos, node_color="#a0cbe2", node_size=node_sizes, ax=ax, edgecolors="black")
+        nx.draw_networkx_labels(subG, pos, font_size=12, font_weight="bold", ax=ax)
+        nx.draw_networkx_edges(
+            subG,
+            pos,
+            edge_color=relation_colors.get(rel_type, "#1f77b4"),
+            width=edge_widths,
+            arrows=True,
+            arrowstyle="->",
+            arrowsize=25,
+            ax=ax,
+            node_size=node_sizes,
+            connectionstyle="arc3,rad=0.1",
+        )
+        nx.draw_networkx_edge_labels(
+            subG,
+            pos,
+            edge_labels={(u, v): f"{d['weight']:,}" for u, v, d in subG.edges(data=True)},
+            font_size=11,
+            font_color="black",
+            ax=ax,
+        )
         ax.axis("off")
-        continue
 
-    pos = nx.spring_layout(subG, k=6.0 / math.sqrt(len(subG.nodes()) + 0.01), seed=42, iterations=100)
-    node_sizes = [dict(subG.degree()).get(n, 1) * 1500 + 800 for n in subG.nodes()]
-    
-    edge_weights = [d['weight'] for _, _, d in subG.edges(data=True)]
-    max_weight = max(edge_weights) if edge_weights else 1
-    edge_widths = [((w / max_weight) * 8) + 1.5 for w in edge_weights]
+    plt.tight_layout(pad=5.0)
+    plt.savefig(graph_path, dpi=300, bbox_inches="tight")
+    plt.close(fig)
 
-    nx.draw_networkx_nodes(subG, pos, node_color="#a0cbe2", node_size=node_sizes, ax=ax, edgecolors='black')
-    nx.draw_networkx_labels(subG, pos, font_size=12, font_weight="bold", ax=ax)
-    nx.draw_networkx_edges(subG, pos, edge_color=relation_colors[rel_type], width=edge_widths, arrows=True, arrowstyle='->', arrowsize=25, ax=ax, node_size=node_sizes, connectionstyle='arc3,rad=0.1')
-    nx.draw_networkx_edge_labels(subG, pos, edge_labels={(u, v): f"{d['weight']:,}" for u, v, d in subG.edges(data=True)}, font_size=11, font_color='black', ax=ax)
-    ax.axis("off")
 
-plt.tight_layout(pad=5.0)
-plt.savefig(GRAPH_IMG_PATH, dpi=300, bbox_inches='tight')
-print(f"KG visualizations saved to: {GRAPH_IMG_PATH}")
+def main() -> None:
+    args = parse_args()
+    try:
+        config = load_configuration(args)
+    except ConfigError as exc:
+        print(f"Configuration error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        detection_model = load_detection_model(config)
+    except ConfigError as exc:
+        print(exc, file=sys.stderr)
+        sys.exit(1)
+
+    relation_counts = process_dataset(detection_model, config["data_splits"], config)
+    if not relation_counts:
+        print("No relations were extracted from the provided datasets.")
+
+    write_prolog_facts(relation_counts, config["facts_path"])
+    print(f"Prolog facts written to: {config['facts_path']}")
+
+    visualise_graph(relation_counts, config["graph_image_path"])
+    print(f"KG visualisations saved to: {config['graph_image_path']}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- refactor the training, pipeline, SAHI prediction, and knowledge-graph scripts to consume YAML/CLI configuration and validate inputs
- add shared configuration helpers plus Kaggle/local sample configs covering each workflow
- refresh the README with instructions for installing dependencies and running the scripts with the new configuration files

## Testing
- python -m compileall training.py 'nsai pipeline.py' 'sahi yolo prediction.py' 'weighted kg +sahi.py' config_utils.py

------
https://chatgpt.com/codex/tasks/task_e_69053f4e0a7083308637e841d45ec0ea