### PR TITLE
Pin dependencies and add CI smoke test

### DIFF
--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -1,0 +1,34 @@
+name: Dependency health check
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+
+jobs:
+  smoke-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y swi-prolog
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Byte-compile source tree
+        run: |
+          python -m compileall training.py pipeline src

--- a/docs/dependency_overview.md
+++ b/docs/dependency_overview.md
@@ -1,0 +1,17 @@
+# Dependency Overview
+
+The following table summarises the third-party dependencies required by the
+command-line entry points in this repository. Standard-library modules and
+intra-repository imports are omitted for brevity.
+
+| Module | Third-party dependencies |
+| --- | --- |
+| `training.py` | `opencv-python`, `tqdm`, `ultralytics` |
+| `nsai pipeline.py` | (none) |
+| `src/sahi_yolo_prediction.py` | `torch`, `sahi` |
+| `src/weighted_kg_sahi.py` | `matplotlib`, `networkx`, `torch`, `sahi` |
+
+All of the packages listed above are pinned in `requirements/common.txt`, while
+hardware-specific PyTorch builds are provided via `requirements.txt`
+(defaulting to CPU wheels) and `requirements-kaggle.txt` (CUDA 12.1 wheels for
+Kaggle runtimes).

--- a/requirements-kaggle.txt
+++ b/requirements-kaggle.txt
@@ -1,0 +1,6 @@
+# Kaggle GPU runtimes provide CUDA 12.1. Use the PyTorch wheels from the official index.
+--extra-index-url https://download.pytorch.org/whl/cu121
+-r requirements/common.txt
+
+torch==2.2.2+cu121
+torchvision==0.17.2+cu121

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,6 @@
-torch
-torchvision
-torchmetrics
-pyswip
-sahi
-numpy
-pandas
-pyyaml
+# Base dependencies shared across CPU and GPU environments
+-r requirements/common.txt
+
+# Default to the CPU-only PyTorch runtime. Override with GPU builds if desired.
+torch==2.2.2
+torchvision==0.17.2

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,0 +1,18 @@
+# Core numerical and data processing libraries
+numpy==1.26.4
+pandas==2.2.2
+pyyaml==6.0.1
+
+# Machine learning utilities
+sahi==0.11.16
+torchmetrics==1.4.0.post0
+ultralytics==8.2.77
+
+# Computer vision and geometry tooling
+opencv-python==4.10.0.84
+tqdm==4.66.4
+matplotlib==3.8.4
+networkx==3.3
+
+# Logic programming bridge
+pyswip==0.2.10


### PR DESCRIPTION
## Summary
- document the third-party dependency surface used by the training and inference entry points
- pin shared dependencies with dedicated CPU and Kaggle CUDA wheels
- add a dependency health GitHub Actions workflow that installs requirements and byte-compiles the codebase

## Testing
- python -m compileall training.py pipeline src

------
https://chatgpt.com/codex/tasks/task_e_6905595dd08c83308c912a0154aba6e2